### PR TITLE
Enable OAuth login with Shopware

### DIFF
--- a/server/shopware.ts
+++ b/server/shopware.ts
@@ -38,6 +38,50 @@ export async function loginShopware(
   return res.json() as Promise<TokenResponse>;
 }
 
+export function getAuthorizeUrl(redirectUri: string, state: string) {
+  if (!BASE_URL || !CLIENT_ID) {
+    throw new Error("Shopware credentials are not configured");
+  }
+
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: CLIENT_ID,
+    redirect_uri: redirectUri,
+    scope: "write",
+    state,
+  });
+
+  return `${BASE_URL}/admin/oauth/authorize?${params.toString()}`;
+}
+
+export async function exchangeAuthorizationCode(
+  code: string,
+  redirectUri: string,
+): Promise<TokenResponse> {
+  if (!BASE_URL || !CLIENT_ID || !CLIENT_SECRET) {
+    throw new Error("Shopware credentials are not configured");
+  }
+
+  const res = await fetch(`${BASE_URL}/api/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "authorization_code",
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+      code,
+      redirect_uri: redirectUri,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Shopware code exchange failed: ${res.status} ${text}`);
+  }
+
+  return res.json() as Promise<TokenResponse>;
+}
+
 export async function getCurrentUser(token: string) {
   if (!BASE_URL) throw new Error("Shopware base URL missing");
   const res = await fetch(`${BASE_URL}/api/search/user`, {


### PR DESCRIPTION
## Summary
- implement OAuth authorization URL and code exchange helpers
- add `/api/auth/oauth` and callback routes for Shopware

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_684821bfa6cc83308a34f1397bac9396